### PR TITLE
build(deps): bump agp from 8.3.1 to 8.3.2 in /manager

### DIFF
--- a/manager/gradle/libs.versions.toml
+++ b/manager/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.3.1"
+agp = "8.3.2"
 kotlin = "1.9.23"
 ksp = "1.9.23-1.0.20"
 compose-compiler = "1.5.11"


### PR DESCRIPTION
Bumps `agp` from 8.3.1 to 8.3.2.

Updates `com.android.application` from 8.3.1 to 8.3.2

Updates `com.android.library` from 8.3.1 to 8.3.2

---
updated-dependencies:
- dependency-name: com.android.application dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: com.android.library dependency-type: direct:production update-type: version-update:semver-patch ...